### PR TITLE
Remove version number from the path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Divolte 
+# Divolte
 #
 # Divolte Documentation:
 # www.divolte.io
@@ -12,18 +12,24 @@ FROM java:8-jre
 RUN mkdir -p /opt/divolte
 
 #
+# Configuration
+#
+ENV DIVOLTE_VERSION 0.6.0
+
+#
 # Download and Install Divolte
 #
-RUN curl -o divolte-collector-0.6.0.tar.gz http://divolte-releases.s3-website-eu-west-1.amazonaws.com/divolte-collector/0.6.0/distributions/divolte-collector-0.6.0.tar.gz && \
-    tar zxpf divolte-collector-0.6.0.tar.gz -C /opt/divolte
+RUN curl -o divolte-collector-${DIVOLTE_VERSION}.tar.gz http://divolte-releases.s3-website-eu-west-1.amazonaws.com/divolte-collector/${DIVOLTE_VERSION}/distributions/divolte-collector-${DIVOLTE_VERSION}.tar.gz && \
+    tar zxpf divolte-collector-${DIVOLTE_VERSION}.tar.gz -C /opt/divolte && \
+    mv /opt/divolte/divolte-collector-${DIVOLTE_VERSION}/ /opt/divolte/divolte-collector
 
 #
 # Configuration changes using divolte-collector.conf
 #
-ADD conf/divolte-collector.conf /opt/divolte/divolte-collector-0.6.0/conf/divolte-collector.conf
-ADD conf/logback.xml /opt/divolte/divolte-collector-0.6.0/conf/logback.xml
-RUN chown root:root /opt/divolte/divolte-collector-0.6.0/conf/divolte-collector.conf
-RUN chown root:root /opt/divolte/divolte-collector-0.6.0/conf/logback.xml
+ADD conf/divolte-collector.conf /opt/divolte/divolte-collector/conf/divolte-collector.conf
+ADD conf/logback.xml /opt/divolte/divolte-collector/conf/logback.xml
+RUN chown root:root /opt/divolte/divolte-collector/conf/divolte-collector.conf && \
+    chown root:root /opt/divolte/divolte-collector/conf/logback.xml
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/README.md
+++ b/README.md
@@ -10,23 +10,23 @@ The following environment variables can influence the default configuration:
 | --- | --- | --- | --- |  
 | DIVOLTE_HOST |  |  | Hostname the application binds on |
 | DIVOLTE_PORT  | 8290 |  | The port the application runs on |
-| DIVOLTE\_USE\_XFORWARDED_FOR | false | true, false | Whether to use the X-Forwarded-For header HTTP header |
-| DIVOLTE\_SERVE\_STATIC_RESOURCES | true | true, false | Serve the static testing page |
-| DIVOLTE\_HDFS_ENABLED | false | true, false | write events in avro format to HDFS | 
-| DIVOLTE\_GFS_ENABLED | false | true, false | write events in avro format to GFS | 
-| DIVOLTE\_KAFKA_ENABLED | true | true, false | write events in avro format to Kafka | 
-| DIVOLTE\_KAFKA_\BROKER_LIST | localhost:9092 |  | The kafka bootstrap server list |
-| DIVOLTE\_KAFKA\_CLIENT_ID | divolte.collector |   | The kafka client id for the producer |
-| DIVOLTE\_PARTY_COOKIE | \_dvp |   | Name of the party coockie |
-| DIVOLTE\_PARTY_TIMEOUT | 730 days |   | Validity of the party coockie |
-| DIVOLTE\_SESSION_COOKIE | \_dvs |   | Name of the session coockie |
-| DIVOLTE\_SESSION_TIMEOUT | 30 minutes |   | Validity of the session coockie |
-| DIVOLTE\_COOKIE_DOMAIN | '' |  | The coockie domain for the coockies |
-| DIVOLTE\_JAVASCRIPT_NAME | divolte.js |   | Name of the js file to nclude in the web application |
-| DIVOLTE\_JAVASCRIPT_LOGGING | false | true, false | Enable javascript logging in the console |
-| DIVOLTE\_JAVASCRIPT_DEBUG | false | true, false | Enable javascript debug logging in the console  |
-| DIVOLTE\_JAVASCRIPT\_AUTO\_PAGE\_VIEW_EVENT | true | true, false | Generate the default page view event on loading the js library |
-| DIVOLTE\_KAFKA_TOPIC | divolte |  | The topic where the events are published |
+| DIVOLTE_USE_XFORWARDED_FOR | false | true, false | Whether to use the X-Forwarded-For header HTTP header |
+| DIVOLTE_SERVE_STATIC_RESOURCES | true | true, false | Serve the static testing page |
+| DIVOLTE_HDFS_ENABLED | false | true, false | write events in avro format to HDFS | 
+| DIVOLTE_GFS_ENABLED | false | true, false | write events in avro format to GFS | 
+| DIVOLTE_KAFKA_ENABLED | true | true, false | write events in avro format to Kafka | 
+| DIVOLTE_KAFKA_\BROKER_LIST | localhost:9092 |  | The kafka bootstrap server list |
+| DIVOLTE_KAFKA_CLIENT_ID | divolte.collector |   | The kafka client id for the producer |
+| DIVOLTE_PARTY_COOKIE | _dvp |   | Name of the party coockie |
+| DIVOLTE_PARTY_TIMEOUT | 730 days |   | Validity of the party coockie |
+| DIVOLTE_SESSION_COOKIE | _dvs |   | Name of the session coockie |
+| DIVOLTE_SESSION_TIMEOUT | 30 minutes |   | Validity of the session coockie |
+| DIVOLTE_COOKIE_DOMAIN | '' |  | The coockie domain for the coockies |
+| DIVOLTE_JAVASCRIPT_NAME | divolte.js |   | Name of the js file to nclude in the web application |
+| DIVOLTE_JAVASCRIPT_LOGGING | false | true, false | Enable javascript logging in the console |
+| DIVOLTE_JAVASCRIPT_DEBUG | false | true, false | Enable javascript debug logging in the console  |
+| DIVOLTE_JAVASCRIPT_AUTO_PAGE_VIEW_EVENT | true | true, false | Generate the default page view event on loading the js library |
+| DIVOLTE_KAFKA_TOPIC | divolte |  | The topic where the events are published |
 
 ## Running the container
 ```

--- a/start.sh
+++ b/start.sh
@@ -5,4 +5,4 @@ if [ ! -z "$ENABLE_KERBEROS" ]; then
   export DIVOLTE_JAVA_OPTS="-Djava.security.krb5.conf=/etc/krb5.conf -Dsun.security.krb5.debug=true"
 fi
 
-/opt/divolte/divolte-collector-0.6.0/bin/divolte-collector
+/opt/divolte/divolte-collector/bin/divolte-collector


### PR DESCRIPTION
For updating Divolte, it is easier to remove the version number from the directory path.