### PR TITLE
Openjdk + Dockerfile refactor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,48 +7,43 @@
 FROM openjdk:8-jre-slim
 
 #
-# Prerequisite: Create some folders for later usage
-#
-RUN mkdir -p /opt/divolte
-
-#
 # Configuration
 #
 
 ARG BUILD_DATE
 ARG DIVOLTE_VERSION=0.7.0
+ARG ENABLE_KERBEROS=no
+ENV ENABLE_KERBEROS=$ENABLE_KERBEROS
+
 
 LABEL org.label-schema.name="Divolte ${DIVOLTE_VERSION}" \
       org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.version=$DIVOLTE_VERSION
 
 #
-# Install dependencies
+# Install dependencies and Divolte
 #
 
 RUN apt-get update && \
-	apt-get install -y curl krb5-user && \ 
-	apt-get clean -y
-
-#
-# Download and Install Divolte
-#
-RUN curl -o divolte-collector-${DIVOLTE_VERSION}.tar.gz http://divolte-releases.s3-website-eu-west-1.amazonaws.com/divolte-collector/${DIVOLTE_VERSION}/distributions/divolte-collector-${DIVOLTE_VERSION}.tar.gz && \
+	if [ "$ENABLE_KERBEROS" = "yes" ]; then\
+		apt-get install -y curl krb5-user;\
+	else\
+		apt-get install -y curl;\
+	fi && \
+	mkdir -p /opt/divolte && \
+    curl -o divolte-collector-${DIVOLTE_VERSION}.tar.gz http://divolte-releases.s3-website-eu-west-1.amazonaws.com/divolte-collector/${DIVOLTE_VERSION}/distributions/divolte-collector-${DIVOLTE_VERSION}.tar.gz && \
     tar zxpf divolte-collector-${DIVOLTE_VERSION}.tar.gz -C /opt/divolte && \
-    mv /opt/divolte/divolte-collector-${DIVOLTE_VERSION}/ /opt/divolte/divolte-collector
+    mv /opt/divolte/divolte-collector-${DIVOLTE_VERSION}/ /opt/divolte/divolte-collector && \
+    rm -f divolte-collector-${DIVOLTE_VERSION}.tar.gz && \
+    apt-get remove -y  curl && \
+    apt-get autoremove -y && \
+    apt-get clean -y
 
 #
 # Configuration changes using divolte-collector.conf
 #
 ADD conf/divolte-collector.conf /opt/divolte/divolte-collector/conf/divolte-collector.conf
 ADD conf/logback.xml /opt/divolte/divolte-collector/conf/logback.xml
-RUN chown root:root /opt/divolte/divolte-collector/conf/divolte-collector.conf && \
-    chown root:root /opt/divolte/divolte-collector/conf/logback.xml
-
-ENV KDC_HOST=${KDC_HOST:-kdc-kadmin}
-ENV REALM ${REALM:-EXAMPLE.COM}
-ENV KADMIN_PRINCIPAL ${KADMIN_PRINCIPAL:-kadmin/admin}
-ENV KADMIN_PASSWORD ${KADMIN_PASSWORD:-MITiys4K5}
 
 COPY configureKerberosClient.sh /opt/divolte/
 COPY start.sh /opt/divolte/

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # www.divolte.io
 #
 
-FROM java:8-jre
+FROM openjdk:8-jre-slim
 
 #
 # Prerequisite: Create some folders for later usage
@@ -14,7 +14,21 @@ RUN mkdir -p /opt/divolte
 #
 # Configuration
 #
-ENV DIVOLTE_VERSION 0.7.0
+
+ARG BUILD_DATE
+ARG DIVOLTE_VERSION=0.7.0
+
+LABEL org.label-schema.name="Divolte ${DIVOLTE_VERSION}" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.version=$DIVOLTE_VERSION
+
+#
+# Install dependencies
+#
+
+RUN apt-get update && \
+	apt-get install -y curl krb5-user && \ 
+	apt-get clean -y
 
 #
 # Download and Install Divolte
@@ -30,13 +44,6 @@ ADD conf/divolte-collector.conf /opt/divolte/divolte-collector/conf/divolte-coll
 ADD conf/logback.xml /opt/divolte/divolte-collector/conf/logback.xml
 RUN chown root:root /opt/divolte/divolte-collector/conf/divolte-collector.conf && \
     chown root:root /opt/divolte/divolte-collector/conf/logback.xml
-
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update && apt-get install -qqy apt-transport-https locales krb5-user netcat && apt-get -qq clean
-
-RUN locale-gen "en_US.UTF-8"
-RUN echo "LC_ALL=\"en_US.UTF-8\"" >> /etc/default/locale
 
 ENV KDC_HOST=${KDC_HOST:-kdc-kadmin}
 ENV REALM ${REALM:-EXAMPLE.COM}

--- a/docker-compose-kerberos.yml
+++ b/docker-compose-kerberos.yml
@@ -43,15 +43,19 @@ services:
 
   # Divolte container
   docker-divolte:
-    build: .
+    build:
+      context: .
+      args:
+        ENABLE_KERBEROS: 'yes'
     container_name: docker-divolte
     hostname: docker-divolte
     domainname: divolte_divolte.io
     environment:
       DIVOLTE_KAFKA_BROKER_LIST: divolte-kafka:9092
-      ENABLE_KERBEROS: "true"
       REALM: EXAMPLE.COM
       KDC_HOST: docker-kdc
+      KADMIN_PRINCIPAL: kadmin/admin
+      KADMIN_PASSWORD: MITiys4K5
       KAFKA_SECURITY_PROTOCOL: SASL_PLAINTEXT
       KAFKA_SASL_JAAS_CONFIG: |-
         com.sun.security.auth.module.Krb5LoginModule required

--- a/docker-compose-kerberos.yml
+++ b/docker-compose-kerberos.yml
@@ -2,7 +2,7 @@ version: "3.3"
 services:
   # Kafka/Zookeeper container
   docker-kdc:
-    image: docker-kdc
+    image: krisgeus/docker-kdc
     container_name: docker-kdc
     hostname: docker-kdc
     domainname: divolte_divolte.io
@@ -16,9 +16,9 @@ services:
       - /dev/urandom:/dev/random
     networks:
       - divolte.io
+
   divolte-kafka:
-    # image: krisgeus/docker-kafka
-    image: docker-kafka
+    image: krisgeus/docker-kafka
     container_name: divolte-kafka
     hostname: divolte-kafka
     domainname: divolte_divolte.io
@@ -36,19 +36,14 @@ services:
       LISTENERS: SASL_PLAINTEXT://0.0.0.0:9092,INTERNAL://0.0.0.0:9093
       SECURITY_PROTOCOL_MAP: SASL_PLAINTEXT:SASL_PLAINTEXT,INTERNAL:PLAINTEXT
       INTER_BROKER: INTERNAL
-    ports:
-      - 9092:9092 # kafka broker
-      - 2181:2181 # Zookeeper
     depends_on:
       - docker-kdc
-    links:
-      - docker-kdc:docker-kdc
     networks:
       - divolte.io
+
   # Divolte container
   docker-divolte:
-    # image: krisgeus/docker-divolte
-    image: docker-divolte
+    build: .
     container_name: docker-divolte
     hostname: docker-divolte
     domainname: divolte_divolte.io

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,9 @@
 version: "3.3"
 services:
+
   # Kafka/Zookeeper container
   divolte-kafka:
     image: krisgeus/docker-kafka
-    container_name: divolte-kafka
-    hostname: divolte-kafka
-    domainname: divolte_divolte.io
     environment:
       ADVERTISED_HOST: divolte-kafka
       LOG_RETENTION_HOURS: 1
@@ -15,28 +13,13 @@ services:
       LISTENERS: PLAINTEXT://0.0.0.0:9092,INTERNAL://0.0.0.0:9093
       SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,INTERNAL:PLAINTEXT
       INTER_BROKER: INTERNAL
-    ports:
-      - 9092:9092 # kafka broker
-      - 2181:2181 # Zookeeper
-    networks:
-      - divolte.io
+
   # Divolte container
   docker-divolte:
-    image: krisgeus/docker-divolte
-    container_name: docker-divolte
-    hostname: docker-divolte
-    domainname: divolte_divolte.io
+    image: godatadriven/divolte
     environment:
       DIVOLTE_KAFKA_BROKER_LIST: divolte-kafka:9092
     ports:
       - 8290:8290
     depends_on:
       - divolte-kafka
-    links:
-      - divolte-kafka:divolte-kafka
-    networks:
-      - divolte.io
-  
-networks:
-  divolte.io:
-    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
 
   # Divolte container
   docker-divolte:
-    image: godatadriven/divolte
+    build: .
     environment:
       DIVOLTE_KAFKA_BROKER_LIST: divolte-kafka:9092
     ports:

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ ! -z "$ENABLE_KERBEROS" ]; then
+if [ "$ENABLE_KERBEROS" = "yes" ]; then
   /opt/divolte/configureKerberosClient.sh
   export DIVOLTE_JAVA_OPTS="-Djava.security.krb5.conf=/etc/krb5.conf -Dsun.security.krb5.debug=true"
 fi


### PR DESCRIPTION
I think we should switch to openjdk as the java image is deprecated and hasn't been updated since 2016-12-31. Moreover, I took the opportunity to change/optimize the Dockerfile a bit to basically create an image with and without kerberos support.